### PR TITLE
Fix typo in sidebar

### DIFF
--- a/_includes/docs-sidebar.html
+++ b/_includes/docs-sidebar.html
@@ -5,7 +5,7 @@
     <li><a href="/docs/setup">Setup</a></li>
     <li><a href="/docs/configuration">Configuration</a></li>
     <li><a href="/docs/tutorial">Absolute Beginner Tutorial</a></li>
-    <li><a href="/docs/quick-reference">Quick Rererence</a></li>
+    <li><a href="/docs/quick-reference">Quick Reference</a></li>
     <li><a href="/docs/resource-uri">Resource URIs</a></li>
     <li><a href="/docs/representation-format">Representation Format</a></li>
     <li><a href="/docs/tutorials">Tutorials</a></li>


### PR DESCRIPTION
"Quick Rererence" changed to "Quick Reference"